### PR TITLE
Authentication Header

### DIFF
--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -1,9 +1,8 @@
 export function authHeader() {
-    // return authorization header with token
     let user = JSON.parse(localStorage.getItem('user'));
 
     if (user && user.token) {
-        return { 'Authorization': 'Bearer ' + user.token };
+        return { 'Authorization': 'JWT ' + user.token };
     } else {
         return {};
     }


### PR DESCRIPTION
Slight changes in our Auth Header functionality.

To use it: 

```
const authHeader = authHeader()

axios.post(`http://127.0.0.1:8000/<endpoint>`, {'username': 'aajjju_bhai'}, { headers: authHeader } )
```